### PR TITLE
Add chart titles from AI prompt and ensure display

### DIFF
--- a/src/api/generateChartData.js
+++ b/src/api/generateChartData.js
@@ -12,7 +12,7 @@ Return ONLY JSON like this:
 [
   {
     "type": "Bar",
-    "title": "Chart Title",
+    "title": "Average Temperature by Month", // the title concisely describes what the chart shows
     "xLabel": "X Axis Label",
     "yLabel": "Y Axis Label",
     "data": [ { "label": "A", "value": 123 }, ... ]
@@ -41,6 +41,7 @@ Instructions per chart type:
 Rules:
 - One chart object per type
 - Use realistic sample values
+- Provide a short title that clearly describes what the chart is showing
 - No explanation or markdown — JSON array only
 
 Topic: "${topic}"

--- a/src/charts/AreaChart.jsx
+++ b/src/charts/AreaChart.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import { Box, Text } from '@chakra-ui/react';
 
-const AreaChart = ({ title, xLabel, yLabel, data }) => {
+const AreaChart = ({ title, data }) => {
   const ref = useRef();
 
   useEffect(() => {

--- a/src/charts/BoxPlotChart.jsx
+++ b/src/charts/BoxPlotChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const BoxPlotChart = ({ data, width = 500, height = 300 }) => {
+const BoxPlotChart = ({ title, data, width = 500, height = 300 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -71,7 +72,12 @@ const BoxPlotChart = ({ data, width = 500, height = 300 }) => {
       .attr('stroke', 'black');
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default BoxPlotChart;

--- a/src/charts/BubbleChart.jsx
+++ b/src/charts/BubbleChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const BubbleChart = ({ data, width = 600, height = 300 }) => {
+const BubbleChart = ({ title, data, width = 600, height = 300 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -66,7 +67,12 @@ const BubbleChart = ({ data, width = 600, height = 300 }) => {
       .style('font-size', '10px');
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default BubbleChart;

--- a/src/charts/DonutChart.jsx
+++ b/src/charts/DonutChart.jsx
@@ -26,7 +26,8 @@ const DonutChart = ({ title, data }) => {
       .append('g')
       .attr('transform', `translate(${width / 2}, ${height / 2})`);
 
-    const arcs = chartGroup.selectAll('path')
+    chartGroup
+      .selectAll('path')
       .data(pie(data))
       .join('path')
       .attr('d', arc)

--- a/src/charts/GaugeChart.jsx
+++ b/src/charts/GaugeChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const GaugeChart = ({ data, width = 300, height = 180 }) => {
+const GaugeChart = ({ title, data, width = 300, height = 180 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -53,7 +54,12 @@ const GaugeChart = ({ data, width = 300, height = 180 }) => {
       .text(`${data.value}%`);
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default GaugeChart;

--- a/src/charts/HeatmapChart.jsx
+++ b/src/charts/HeatmapChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const HeatmapChart = ({ data, width = 500, height = 400 }) => {
+const HeatmapChart = ({ title, data, width = 500, height = 400 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -54,7 +55,12 @@ const HeatmapChart = ({ data, width = 500, height = 400 }) => {
       .style('font-size', '10px');
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default HeatmapChart;

--- a/src/charts/HistogramChart.jsx
+++ b/src/charts/HistogramChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const HistogramChart = ({ data, width = 600, height = 300 }) => {
+const HistogramChart = ({ title, data, width = 600, height = 300 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -56,7 +57,12 @@ const HistogramChart = ({ data, width = 600, height = 300 }) => {
     chart.append('g').call(d3.axisLeft(y));
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default HistogramChart;

--- a/src/charts/RadarChart.jsx
+++ b/src/charts/RadarChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const RadarChart = ({ data, width = 500, height = 500 }) => {
+const RadarChart = ({ title, data, width = 500, height = 500 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -80,7 +81,12 @@ const RadarChart = ({ data, width = 500, height = 500 }) => {
       .attr('stroke-width', 2);
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default RadarChart;

--- a/src/charts/ScatterPlot.jsx
+++ b/src/charts/ScatterPlot.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import { Box, Text } from '@chakra-ui/react';
 
-const ScatterPlot = ({ title, xLabel, yLabel, data }) => {
+const ScatterPlot = ({ title, data }) => {
   const ref = useRef();
 
   useEffect(() => {

--- a/src/charts/StackedBarChart.jsx
+++ b/src/charts/StackedBarChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const StackedBarChart = ({ data, width = 600, height = 350 }) => {
+const StackedBarChart = ({ title, data, width = 600, height = 350 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -58,7 +59,12 @@ const StackedBarChart = ({ data, width = 600, height = 350 }) => {
       .attr('width', x.bandwidth());
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default StackedBarChart;

--- a/src/charts/SunburstChart.jsx
+++ b/src/charts/SunburstChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const SunburstChart = ({ data, width = 500, height = 500 }) => {
+const SunburstChart = ({ title, data, width = 500, height = 500 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -42,7 +43,12 @@ const SunburstChart = ({ data, width = 500, height = 500 }) => {
       .text((d) => `${d.data.name}\n${d.value}`);
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default SunburstChart;

--- a/src/charts/TimelineChart.jsx
+++ b/src/charts/TimelineChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const TimelineChart = ({ data, width = 700, height = 300 }) => {
+const TimelineChart = ({ title, data, width = 700, height = 300 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -60,7 +61,12 @@ const TimelineChart = ({ data, width = 700, height = 300 }) => {
       .attr('fill', '#2d3748');
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default TimelineChart;

--- a/src/charts/TreemapChart.jsx
+++ b/src/charts/TreemapChart.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { Box, Text } from '@chakra-ui/react';
 
-const TreemapChart = ({ data, width = 600, height = 400 }) => {
+const TreemapChart = ({ title, data, width = 600, height = 400 }) => {
   const svgRef = useRef();
 
   useEffect(() => {
@@ -41,7 +42,12 @@ const TreemapChart = ({ data, width = 600, height = 400 }) => {
       .attr('fill', 'white');
   }, [data]);
 
-  return <svg ref={svgRef} width={width} height={height} />;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb={2}>{title}</Text>
+      <svg ref={svgRef} width={width} height={height} />
+    </Box>
+  );
 };
 
 export default TreemapChart;


### PR DESCRIPTION
## Summary
- update OpenAI prompt so each chart title describes its content
- render chart titles in every chart component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889e9b838548332aa8bfd9d4bd821f7