### PR TITLE
Add OpenAI random question feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,12 +11,17 @@ import {
   Flex,
   Wrap,
   WrapItem,
+  InputGroup,
+  InputRightElement,
+  IconButton,
 } from '@chakra-ui/react';
+import { RepeatIcon } from '@chakra-ui/icons';
 
 import ChartTypeSelector from './components/ChartTypeSelector';
 import ChartContainer from './components/ChartContainer';
 import generateChartData from './api/generateChartData';
 import suggestChartTypes from './api/suggestChartTypes';
+import getRandomQuestion from './api/getRandomQuestion';
 
 const App = () => {
   const [topic, setTopic] = useState('');
@@ -25,7 +30,25 @@ const App = () => {
   const [suggestedTypes, setSuggestedTypes] = useState([]);
   const [suggestionLoading, setSuggestionLoading] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [randomLoading, setRandomLoading] = useState(false);
   const toast = useToast();
+
+  const handleRandomQuestion = async () => {
+    setRandomLoading(true);
+    try {
+      const question = await getRandomQuestion();
+      setTopic(question);
+    } catch (err) {
+      toast({
+        title: 'Failed to fetch random question.',
+        description: err.message || 'Something went wrong.',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+    setRandomLoading(false);
+  };
 
   // Debounced suggestion call
   useEffect(() => {
@@ -76,12 +99,23 @@ const App = () => {
         <Heading size="lg" textAlign="center">📊 Chartify</Heading>
 
         <Flex gap={3}>
-          <Input
-            placeholder="Enter a topic (e.g. population growth, climate change)"
-            value={topic}
-            onChange={(e) => setTopic(e.target.value)}
-            flex="1"
-          />
+          <InputGroup flex="1">
+            <Input
+              placeholder="Enter a topic (e.g. population growth, climate change)"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+            />
+            <InputRightElement width="2.5rem">
+              <IconButton
+                aria-label="Random question"
+                icon={<RepeatIcon />}
+                size="sm"
+                variant="ghost"
+                onClick={handleRandomQuestion}
+                isLoading={randomLoading}
+              />
+            </InputRightElement>
+          </InputGroup>
           <Button
             colorScheme="teal"
             onClick={handleGenerate}

--- a/src/api/getRandomQuestion.js
+++ b/src/api/getRandomQuestion.js
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY;
+
+const getRandomQuestion = async () => {
+  const prompt = 'Provide one short, interesting data analysis question that a user might ask about the world. Respond with the question only.';
+
+  const response = await axios.post(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You generate creative, concise data-related questions.' },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.7,
+      max_tokens: 50,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  const content = response.data.choices[0].message.content.trim();
+  return content.replace(/^"|"$/g, '');
+};
+
+export default getRandomQuestion;


### PR DESCRIPTION
## Summary
- remove static random questions
- add API call to OpenAI for a random question
- wire up loading random questions from the repeat icon button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889ef2c2dbc8332a994eedc09dfdfbc